### PR TITLE
issues #5 - commmand line stage option

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,9 @@ class LogForwardingPlugin {
     // Get options and parameters to make resources object
     const serviceName = service.service;
     const arn = service.custom.logForwarding.destinationARN;
-    const stage = options.stage && options.stage.length > 0 ? options.stage : service.provider.stage;
+    const stage = options.stage && options.stage.length > 0 
+                  ? options.stage 
+                  : service.provider.stage;
     // Get list of all functions in this lambda
     const functions = _.keys(service.functions);
     const principal = `logs.${service.provider.region}.amazonaws.com`;

--- a/index.js
+++ b/index.js
@@ -1,8 +1,9 @@
 const _ = require('underscore');
 
 class LogForwardingPlugin {
-  constructor(serverless) {
+  constructor(serverless, options) {
     this.serverless = serverless;
+    this.options = options;
 
     /* Hooks tell Serverless when to do what */
     this.hooks = {
@@ -33,6 +34,7 @@ class LogForwardingPlugin {
    */
   createResourcesObj() {
     const service = this.serverless.service;
+    const options = this.options;
     // Checks if the serverless file is setup correctly
     if (service.custom.logForwarding.destinationARN == null) {
       throw new Error('Serverless-log-forwarding is not configured correctly. Please see README for proper setup.');
@@ -41,7 +43,7 @@ class LogForwardingPlugin {
     // Get options and parameters to make resources object
     const serviceName = service.service;
     const arn = service.custom.logForwarding.destinationARN;
-    const stage = service.provider.stage;
+    const stage = options.stage && options.stage.length > 0 ? options.stage : service.provider.stage;
     // Get list of all functions in this lambda
     const functions = _.keys(service.functions);
     const principal = `logs.${service.provider.region}.amazonaws.com`;

--- a/index.js
+++ b/index.js
@@ -43,8 +43,8 @@ class LogForwardingPlugin {
     // Get options and parameters to make resources object
     const serviceName = service.service;
     const arn = service.custom.logForwarding.destinationARN;
-    const stage = options.stage && options.stage.length > 0 
-                  ? options.stage 
+    const stage = options.stage && options.stage.length > 0
+                  ? options.stage
                   : service.provider.stage;
     // Get list of all functions in this lambda
     const functions = _.keys(service.functions);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-log-forwarding",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "a serverless plugin to forward logs to given lambda function",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
Introduction of the serverless options so the `--stage` argument can be used from command line.

I have tested this change on app, not sure how you'd want tests implemented to recreate command line interaction :-/

I couldn't get the tests to run :-/   Not that they run and failed, they wouldn't run locally. I entered `npm install` before `npm test` :(