### PR TITLE
Use Serverless naming module to format log group name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 coverage
 npm-debug.log
 .idea
+.vscode

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "serverless": "^1.20.2"
   },
   "scripts": {
-    "test": "node ./node_modules/istanbul/lib/cli.js cover _mocha -- -R spec && node ./node_modules/istanbul/lib/cli.js check-coverage --line 70 coverage/coverage.json",
+    "test": "node ./node_modules/istanbul/lib/cli.js cover ./node_modules/mocha/bin/_mocha -- -R spec && node ./node_modules/istanbul/lib/cli.js check-coverage --line 70 coverage/coverage.json",
     "lint": "eslint ."
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-log-forwarding",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "a serverless plugin to forward logs to given lambda function",
   "main": "index.js",
   "directories": {

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -129,7 +129,7 @@ describe('Given a serverless config', () => {
             Principal: 'logs.us-moon-1.amazonaws.com',
           },
         },
-        SubscriptionFiltertestFunctionOne: {
+        SubscriptionFilterTestFunctionOne: {
           Type: 'AWS::Logs::SubscriptionFilter',
           Properties: {
             DestinationArn: 'arn:aws:lambda:us-moon-1:314159265358:function:testforward-test-forward',
@@ -141,7 +141,7 @@ describe('Given a serverless config', () => {
             'TestFunctionOneLogGroup',
           ],
         },
-        SubscriptionFiltertestFunctionTwo: {
+        SubscriptionFilterTestFunctionTwo: {
           Type: 'AWS::Logs::SubscriptionFilter',
           Properties: {
             DestinationArn: 'arn:aws:lambda:us-moon-1:314159265358:function:testforward-test-forward',
@@ -173,7 +173,7 @@ describe('Given a serverless config', () => {
             Principal: 'logs.us-moon-1.amazonaws.com',
           },
         },
-        SubscriptionFiltertestFunctionOne: {
+        SubscriptionFilterTestFunctionOne: {
           Type: 'AWS::Logs::SubscriptionFilter',
           Properties: {
             DestinationArn: 'arn:aws:lambda:us-moon-1:314159265358:function:testforward-dev-forward',
@@ -185,7 +185,7 @@ describe('Given a serverless config', () => {
             'TestFunctionOneLogGroup',
           ],
         },
-        SubscriptionFiltertestFunctionTwo: {
+        SubscriptionFilterTestFunctionTwo: {
           Type: 'AWS::Logs::SubscriptionFilter',
           Properties: {
             DestinationArn: 'arn:aws:lambda:us-moon-1:314159265358:function:testforward-dev-forward',
@@ -214,7 +214,7 @@ describe('Given a serverless config', () => {
             Principal: 'logs.us-moon-1.amazonaws.com',
           },
         },
-        SubscriptionFiltertestFunctionOne: {
+        SubscriptionFilterTestFunctionOne: {
           Type: 'AWS::Logs::SubscriptionFilter',
           Properties: {
             DestinationArn: 'arn:aws:lambda:us-moon-1:314159265358:function:testforward-test-forward',
@@ -226,7 +226,7 @@ describe('Given a serverless config', () => {
             'TestFunctionOneLogGroup',
           ],
         },
-        SubscriptionFiltertestFunctionTwo: {
+        SubscriptionFilterTestFunctionTwo: {
           Type: 'AWS::Logs::SubscriptionFilter',
           Properties: {
             DestinationArn: 'arn:aws:lambda:us-moon-1:314159265358:function:testforward-test-forward',
@@ -258,7 +258,7 @@ describe('Given a serverless config', () => {
             Principal: 'logs.us-moon-1.amazonaws.com',
           },
         },
-        SubscriptionFiltertestFunctionOne: {
+        SubscriptionFilterTestFunctionOne: {
           Type: 'AWS::Logs::SubscriptionFilter',
           Properties: {
             DestinationArn: 'arn:aws:lambda:us-moon-1:314159265358:function:testforward-test-forward',
@@ -270,7 +270,7 @@ describe('Given a serverless config', () => {
             'TestFunctionOneLogGroup',
           ],
         },
-        SubscriptionFiltertestFunctionTwo: {
+        SubscriptionFilterTestFunctionTwo: {
           Type: 'AWS::Logs::SubscriptionFilter',
           Properties: {
             DestinationArn: 'arn:aws:lambda:us-moon-1:314159265358:function:testforward-test-forward',


### PR DESCRIPTION
There is an issue with this plugin when using custom naming convention by overriding [naming module](/serverless/serverless/blob/master/lib/plugins/aws/lib/naming.js) in AWS provider in Serverless. This PR uses naming module when forming `logGroupName`.

I had to update tests to use actual Serverless instance with AWS provider plugin.

I've also had to remove explicit function names from test configuration as they are used to override function names for deployed lambdas.