### PR TITLE
Bugfix/add function log group as dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,6 +53,7 @@ class LogForwardingPlugin {
     const filterPattern = service.custom.logForwarding.filterPattern || '';
     // Get options and parameters to make resources object
     const serviceName = service.service;
+    const awsProvider = this.serverless.getProvider('aws');
     const arn = service.custom.logForwarding.destinationARN;
     const stage = options.stage && options.stage.length > 0
       ? options.stage
@@ -74,8 +75,9 @@ class LogForwardingPlugin {
     };
     for (let i = 0; i < functions.length; i += 1) {
       /* merge new SubscriptionFilter with current resources object */
+      const functionLogGroupId = awsProvider.naming.getLogGroupLogicalId(functions[i]);
       const subscriptionFilter = LogForwardingPlugin.makeSubscriptionFilter(serviceName,
-        stage, arn, functions[i], filterPattern);
+        stage, arn, functions[i], filterPattern, functionLogGroupId);
       _.extend(resourceObj, subscriptionFilter);
     }
     return resourceObj;
@@ -89,9 +91,11 @@ class LogForwardingPlugin {
    * @param  {String} arn          arn of the lambda to forward to
    * @param  {String} functionName name of function to make SubscriptionFilter for
    * @param  {String} filterPattern filter pattern for the Subscription
+   * @param  {String} functionLogGroupId name of the function Log Group to add as a dependency
    * @return {Object}               SubscriptionFilter
    */
-  static makeSubscriptionFilter(serviceName, stage, arn, functionName, filterPattern) {
+  static makeSubscriptionFilter(serviceName, stage, arn, functionName, filterPattern,
+    functionLogGroupId) {
     const logGroupName = `/aws/lambda/${serviceName}-${stage}-${functionName}`;
     const filter = {};
     filter[`SubscriptionFilter${functionName}`] = {
@@ -103,6 +107,7 @@ class LogForwardingPlugin {
       },
       DependsOn: [
         'LogForwardingLambdaPermission',
+        functionLogGroupId,
       ],
     };
     return filter;

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "eslint-plugin-jsx-a11y": "^3.0.2",
     "eslint-plugin-react": "^6.10.3",
     "istanbul": "^0.4.5",
-    "mocha": "^2.2.5"
+    "mocha": "^2.2.5",
+    "serverless": "^1.20.2"
   },
   "scripts": {
     "test": "node ./node_modules/istanbul/lib/cli.js cover _mocha -- -R spec && node ./node_modules/istanbul/lib/cli.js check-coverage --line 70 coverage/coverage.json",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-log-forwarding",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "a serverless plugin to forward logs to given lambda function",
   "main": "index.js",
   "directories": {

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -19,118 +19,98 @@ const correctConfigWithStageFilter = {
   stages: ['production'],
 };
 
-const awsProviderMock = (provider) => {
-  if (provider !== 'aws') {
-    throw new Error('provider must be aws');
-  }
-  return {
-    naming: {
-      getLogGroupLogicalId: functionName => `${functionName.charAt(0).toUpperCase()}${functionName.slice(1)}LogGroup`,
+const Serverless = require('serverless');
+const AwsProvider = require('serverless/lib/plugins/aws/provider/awsProvider');
+
+const createServerless = (options, service) => {
+  const serverless = new Serverless(options);
+  serverless.cli = {
+    log() {
     },
   };
+  new AwsProvider(serverless, options); // eslint-disable-line no-new
+  serverless.service.update(service);
+  serverless.service.setFunctionNames(options);
+  return serverless;
 };
 
 const constructPluginResources = (logForwarding) => {
-  const serverless = {
-    service: {
-      provider: {
-        region: 'us-moon-1',
-        stage: 'test-stage',
-      },
-      custom: {
-        logForwarding,
-      },
-      resources: {
-        Resources: {
-          TestExistingFilter: {
-            Type: 'AWS:Test:Filter',
-          },
-        },
-      },
-      functions: {
-        testFunctionOne: {
-          name: 'functionOne',
-          filterPattern: 'Pattern',
-        },
-        testFunctionTwo: {
-          name: 'functionTwo',
-        },
-      },
-      service: 'test-service',
+  const options = {};
+  const serverless = createServerless(options, {
+    provider: {
+      region: 'us-moon-1',
+      stage: 'test-stage',
     },
-    getProvider: awsProviderMock,
-    cli: {
-      log() {
+    custom: {
+      logForwarding,
+    },
+    resources: {
+      Resources: {
+        TestExistingFilter: {
+          Type: 'AWS:Test:Filter',
+        },
       },
     },
-  };
-  return new LogForwardingPlugin(serverless, {});
+    functions: {
+      testFunctionOne: {
+        filterPattern: 'Pattern',
+      },
+      testFunctionTwo: {
+      },
+    },
+    service: 'test-service',
+  });
+  return new LogForwardingPlugin(serverless, options);
 };
 const constructPluginNoResources = (logForwarding) => {
-  const serverless = {
-    service: {
-      provider: {
-        region: 'us-moon-1',
-        stage: 'test-stage',
-      },
-      custom: {
-        logForwarding,
-      },
-      resources: undefined,
-      functions: {
-        testFunctionOne: {
-          name: 'functionOne',
-        },
-        testFunctionTwo: {
-          name: 'functionTwo',
-        },
-      },
-      service: 'test-service',
+  const options = {};
+  const serverless = createServerless(options, {
+    provider: {
+      region: 'us-moon-1',
+      stage: 'test-stage',
     },
-    getProvider: awsProviderMock,
-    cli: {
-      log() {
+    custom: {
+      logForwarding,
+    },
+    functions: {
+      testFunctionOne: {
+      },
+      testFunctionTwo: {
       },
     },
-  };
-  return new LogForwardingPlugin(serverless, {});
+    service: 'test-service',
+  });
+  serverless.service.resources = undefined;
+  return new LogForwardingPlugin(serverless, options);
 };
 
 const constructPluginResourcesWithParam = (logForwarding) => {
-  const serverless = {
-    service: {
-      provider: {
-        region: 'us-moon-1',
-        stage: 'test-stage',
-      },
-      custom: {
-        logForwarding,
-      },
-      resources: {
-        Resources: {
-          TestExistingFilter: {
-            Type: 'AWS:Test:Filter',
-          },
-        },
-      },
-      functions: {
-        testFunctionOne: {
-          name: 'functionOne',
-          filterPattern: 'Pattern',
-        },
-        testFunctionTwo: {
-          name: 'functionTwo',
-        },
-      },
-      service: 'test-service',
+  const options = { stage: 'dev' };
+  const serverless = createServerless(options, {
+    provider: {
+      region: 'us-moon-1',
+      stage: 'test-stage',
     },
-    getProvider: awsProviderMock,
-    cli: {
-      log() {
+    custom: {
+      logForwarding,
+    },
+    resources: {
+      Resources: {
+        TestExistingFilter: {
+          Type: 'AWS:Test:Filter',
+        },
       },
     },
-  };
-  return new LogForwardingPlugin(serverless, { stage: 'dev' });
+    functions: {
+      testFunctionOne: {
+        filterPattern: 'Pattern',
+      },
+      testFunctionTwo: {
+      },
+    },
+    service: 'test-service',
+  });
+  return new LogForwardingPlugin(serverless, options);
 };
 
 describe('Given a serverless config', () => {

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -19,7 +19,7 @@ const correctConfigWithStageFilter = {
   stages: ['production'],
 };
 
-const awsProvider = (provider) => {
+const awsProviderMock = (provider) => {
   if (provider !== 'aws') {
     throw new Error('provider must be aws');
   }
@@ -58,7 +58,7 @@ const constructPluginResources = (logForwarding) => {
       },
       service: 'test-service',
     },
-    getProvider: awsProvider,
+    getProvider: awsProviderMock,
     cli: {
       log() {
       },
@@ -87,7 +87,7 @@ const constructPluginNoResources = (logForwarding) => {
       },
       service: 'test-service',
     },
-    getProvider: awsProvider,
+    getProvider: awsProviderMock,
     cli: {
       log() {
       },
@@ -124,7 +124,7 @@ const constructPluginResourcesWithParam = (logForwarding) => {
       },
       service: 'test-service',
     },
-    getProvider: awsProvider,
+    getProvider: awsProviderMock,
     cli: {
       log() {
       },

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -18,6 +18,18 @@ const correctConfigWithStageFilter = {
   filterPattern: 'Test Pattern',
   stages: ['production'],
 };
+
+const awsProvider = (provider) => {
+  if (provider !== 'aws') {
+    throw new Error('provider must be aws');
+  }
+  return {
+    naming: {
+      getLogGroupLogicalId: functionName => `${functionName.charAt(0).toUpperCase()}${functionName.slice(1)}LogGroup`,
+    },
+  };
+};
+
 const constructPluginResources = (logForwarding) => {
   const serverless = {
     service: {
@@ -46,6 +58,7 @@ const constructPluginResources = (logForwarding) => {
       },
       service: 'test-service',
     },
+    getProvider: awsProvider,
     cli: {
       log() {
       },
@@ -74,6 +87,7 @@ const constructPluginNoResources = (logForwarding) => {
       },
       service: 'test-service',
     },
+    getProvider: awsProvider,
     cli: {
       log() {
       },
@@ -110,6 +124,7 @@ const constructPluginResourcesWithParam = (logForwarding) => {
       },
       service: 'test-service',
     },
+    getProvider: awsProvider,
     cli: {
       log() {
       },
@@ -143,6 +158,7 @@ describe('Given a serverless config', () => {
           },
           DependsOn: [
             'LogForwardingLambdaPermission',
+            'TestFunctionOneLogGroup',
           ],
         },
         SubscriptionFiltertestFunctionTwo: {
@@ -154,6 +170,7 @@ describe('Given a serverless config', () => {
           },
           DependsOn: [
             'LogForwardingLambdaPermission',
+            'TestFunctionTwoLogGroup',
           ],
         },
       },
@@ -185,6 +202,7 @@ describe('Given a serverless config', () => {
           },
           DependsOn: [
             'LogForwardingLambdaPermission',
+            'TestFunctionOneLogGroup',
           ],
         },
         SubscriptionFiltertestFunctionTwo: {
@@ -196,6 +214,7 @@ describe('Given a serverless config', () => {
           },
           DependsOn: [
             'LogForwardingLambdaPermission',
+            'TestFunctionTwoLogGroup',
           ],
         },
       },
@@ -224,6 +243,7 @@ describe('Given a serverless config', () => {
           },
           DependsOn: [
             'LogForwardingLambdaPermission',
+            'TestFunctionOneLogGroup',
           ],
         },
         SubscriptionFiltertestFunctionTwo: {
@@ -235,6 +255,7 @@ describe('Given a serverless config', () => {
           },
           DependsOn: [
             'LogForwardingLambdaPermission',
+            'TestFunctionTwoLogGroup',
           ],
         },
       },
@@ -266,6 +287,7 @@ describe('Given a serverless config', () => {
           },
           DependsOn: [
             'LogForwardingLambdaPermission',
+            'TestFunctionOneLogGroup',
           ],
         },
         SubscriptionFiltertestFunctionTwo: {
@@ -277,6 +299,7 @@ describe('Given a serverless config', () => {
           },
           DependsOn: [
             'LogForwardingLambdaPermission',
+            'TestFunctionTwoLogGroup',
           ],
         },
       },


### PR DESCRIPTION
There is an issue with the `serverless-log-forwarding` plugin when a new lambda is added to an existing serverless application. The error looks like the following `An error occurred while provisioning your stack: SubscriptionFilterhelloWorld2 - The specified log group does not exist..`

So this PR is about adding the function log group id as a dependency to ensure the LogGroup resource exists prior creating the subscription filter resource.

I also used the `createServerless` of PR #7 for better testing with the aws provider.