### PR TITLE
Add per-function filter exclusion option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
@@ -6,14 +7,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Added support for per-function exclusion by setting `functions.function.logForwarding.enabled = false` for the given function.
 
 ## [1.1.8] - 2018-07-30
 
 ### Added
+
 - Added option to support filename as filter logic id, called `normalizedFilterID`. True by default.
 
 
 ## [1.1.7] - 2018-07-30
 
 ### Added
+
 - This CHANGELOG file to make it easier for future updates to be documented. Sadly, will not be going back to document changes made for previous versions.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # serverless-log-forwarding
+
 [![serverless](http://public.serverless.com/badges/v3.svg)](http://www.serverless.com)
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/amplify-education/serverless-domain-manager/master/LICENSE)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/bb1e50c048434012bd57eb73225a089e)](https://www.codacy.com/app/CFER/serverless-log-forwarding?utm_source=github.com&utm_medium=referral&utm_content=amplify-education/serverless-log-forwarding&utm_campaign=badger)
@@ -9,24 +10,28 @@
 Serverless plugin for forwarding CloudWatch logs to another Lambda function.
 
 # About Amplify
+
 Amplify builds innovative and compelling digital educational products that empower teachers and students across the country. We have a long history as the leading innovator in K-12 education - and have been described as the best tech company in education and the best education company in tech. While others try to shrink the learning experience into the technology, we use technology to expand what is possible in real classrooms with real students and teachers.
 
 # Getting Started
 
 ## Prerequisites
+
 Make sure you have the following installed before starting:
 * [nodejs](https://nodejs.org/en/download/)
 * [npm](https://www.npmjs.com/get-npm)
 * [serverless](https://serverless.com/framework/docs/providers/aws/guide/installation/)
 
 ## Installing
+
 To install the plugin, run:
 
-```
+```shell
 npm install serverless-log-forwarding
 ```
 
-Then make the following edits to your serverless.yaml file:
+Then make the following edits to your `serverless.yaml` file:
+
 ```yaml
 plugins:
   - serverless-log-forwarding
@@ -40,32 +45,48 @@ custom:
     stages:
       - '[name of the stage to apply log forwarding]'
       - '[another stage name to filter]'
+
+functions:
+  myFunction:
+    handler: src/someHandler
+    # optional properties for per-function configuration:
+    logForwarding:
+      # set enabled to false to disable log forwarding for a single given function
+      enabled: false
+
 ```
 
 ## Running Tests
+
 To run the test:
-```
+
+```shell
 npm test
 ```
+
 All tests should pass.
 
 If there is an error update the node_module inside the serverless-log-forwarding folder:
-```
+
+```shell
 npm install
 ```
 
 ## Deploying
 ---------
 The plugin will be packaged with the lambda when deployed as normal using Serverless:
-```
+
+```shell
 serverless deploy
 ```
 
 # Responsible Disclosure
+
 If you have any security issue to report, contact project maintainers privately.
 You can reach us at <github@amplify.com>
 
 # Contributing
+
 We welcome pull requests! For your pull request to be accepted smoothly, we suggest that you:
 1. For any sizable change, first open a GitHub issue to discuss your idea.
 2. Create a pull request.  Explain why you want to make the change and what it’s for.

--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ class LogForwardingPlugin {
         },
       },
     };
-        /* get list of all functions in this lambda
+    /* get list of all functions in this lambda
       and filter by those which explicitly declare logForwarding = false
     */
     _.keys(service.functions)

--- a/index.js
+++ b/index.js
@@ -75,8 +75,8 @@ class LogForwardingPlugin {
     */
     _.keys(service.functions)
       .filter((func) => {
-        const { logForwarding } = this.serverless.service.getFunction(func);
-        return typeof logForwarding === 'undefined' || logForwarding === true;
+        const { logForwarding = {} } = this.serverless.service.getFunction(func);
+        return typeof logForwarding.enabled === 'undefined' || logForwarding.enabled === true;
       })
       .forEach((func) => {
         const subscriptionFilter = this.makeSubscriptionFilter(func, {

--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ class LogForwardingPlugin {
       },
     };
     /* get list of all functions in this lambda
-      and filter by those which explicitly declare logForwarding = false
+      and filter by those which explicitly declare logForwarding.enabled = false
     */
     _.keys(service.functions)
       .filter((func) => {

--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ class LogForwardingPlugin {
     */
     _.keys(service.functions)
       .filter((func) => {
-        const logForwarding = this.serverless.service.getFunction(func).logForwarding;
+        const { logForwarding } = this.serverless.service.getFunction(func);
         return typeof logForwarding === 'undefined' || logForwarding === true;
       })
       .forEach((func) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-log-forwarding",
-  "version": "1.1.8",
+  "version": "1.2.0",
   "description": "a serverless plugin to forward logs to given lambda function",
   "main": "index.js",
   "directories": {

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -289,15 +289,22 @@ describe('Given a serverless config', () => {
     expect(plugin.serverless.service.resources).to.eql(expectedResources);
   });
 
-  it('excludes functions with logForwarding=false from AWS::Logs::SubscriptionFilter output', () => {
+  it('excludes functions with logForwarding.enabled=false from AWS::Logs::SubscriptionFilter output', () => {
     const plugin = constructPluginResources(correctConfigWithFilterPattern, {
       testFunctionOne: {
       },
       testFunctionTwo: {
-        logForwarding: true,
+        logForwarding: {},
       },
       testFunctionThree: {
-        logForwarding: false,
+        logForwarding: {
+          enabled: true,
+        },
+      },
+      testFunctionFour: {
+        logForwarding: {
+          enabled: false,
+        },
       },
     });
     const expectedResources = {
@@ -335,6 +342,18 @@ describe('Given a serverless config', () => {
           DependsOn: [
             'LogForwardingLambdaPermission',
             'TestFunctionTwoLogGroup',
+          ],
+        },
+        SubscriptionFiltertestFunctionThree: {
+          Type: 'AWS::Logs::SubscriptionFilter',
+          Properties: {
+            DestinationArn: 'arn:aws:lambda:us-moon-1:314159265358:function:testforward-test-forward',
+            FilterPattern: 'Test Pattern',
+            LogGroupName: '/aws/lambda/test-service-test-stage-testFunctionThree',
+          },
+          DependsOn: [
+            'LogForwardingLambdaPermission',
+            'TestFunctionThreeLogGroup',
           ],
         },
       },


### PR DESCRIPTION
Allow users to set 
```yaml
logForwarding: false
``` 
on any given function. This excludes the function from the array of log group subscriptions generated.

This is useful in a few cases, e.g. a high traffic function which returns a static response.

It may be preferable to add `filterPattern` as an option on each function so a match-nothing pattern can be set, or have a new `logForwarding` object as an option on each function to make this extensible in future, although having a `false` boolean does not preclude this usage as a non-breaking change.