### PR TITLE
add support for disabledLambdaPermission option when policy size limits are a concern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [1.2.1] - 2019-10-09
+## [1.2.2] - 2018-10-24
+
+### Added
+
+- Added option, called `disabledLambdaPermission`, to support disabling the creation of a AWS::Lambda::Permission. False by default.
+
+## [1.2.1] - 2018-10-09
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ custom:
     stages:
       - '[name of the stage to apply log forwarding]'
       - '[another stage name to filter]'
+    disabledLambdaPermission: false # whether to disable creation of the AWS::Lambda::Permission for the destinationARN (when policy size limits are a concern)
 
 functions:
   myFunction:

--- a/index.js
+++ b/index.js
@@ -54,22 +54,31 @@ class LogForwardingPlugin {
     }
     const filterPattern = service.custom.logForwarding.filterPattern || '';
     const normalizedFilterID = !(service.custom.logForwarding.normalizedFilterID === false);
+    const disabledLambdaPermission = service.custom.logForwarding.disabledLambdaPermission === true;
     // Get options and parameters to make resources object
     const arn = service.custom.logForwarding.destinationARN;
     // Get list of all functions in this lambda
     const principal = `logs.${service.provider.region}.amazonaws.com`;
     // Generate resources object for each function
-    // Only one lambda permission is needed
-    const resourceObj = {
-      LogForwardingLambdaPermission: {
-        Type: 'AWS::Lambda::Permission',
-        Properties: {
-          FunctionName: arn,
-          Action: 'lambda:InvokeFunction',
-          Principal: principal,
+    const resourceObj = {};
+
+    // Only one lambda permission is needed if it is not disabled
+    // The Lambda permission should only be disabled if this plugin is used in numerous (e.g. 70+) serverless projects
+    // that deploy to the same destinationARN within the same AWS account. There is a 20kb function policy limit that may
+    // be exceeded by the destination function policy in this case.
+    // If disabled, the user will be expected to create this lambda permission for the destination function by other means
+    if (!disabledLambdaPermission) {
+      _.extend(resourceObj, {
+        LogForwardingLambdaPermission: {
+          Type: 'AWS::Lambda::Permission',
+          Properties: {
+            FunctionName: arn,
+            Action: 'lambda:InvokeFunction',
+            Principal: principal,
+          },
         },
-      },
-    };
+      });
+    }
     /* get list of all functions in this lambda
       and filter by those which explicitly declare logForwarding.enabled = false
     */
@@ -83,6 +92,7 @@ class LogForwardingPlugin {
           arn,
           filterPattern,
           normalizedFilterID,
+          dependsOn: disabledLambdaPermission ? [] : ['LogForwardingLambdaPermission'],
         });
         /* merge new SubscriptionFilter with current resources object */
         _.extend(resourceObj, subscriptionFilter);
@@ -97,6 +107,7 @@ class LogForwardingPlugin {
    *                          arn: arn of the lambda to forward to
    *                          filterPattern: filter pattern for the Subscription
    *                          normalizedFilterID: whether to use normalized FuncName as filter ID
+   *                          dependsOn: array of additional CloudFormation template resources the filter should depend on
    * @return {Object}               SubscriptionFilter
    */
   makeSubscriptionFilter(functionName, options) {
@@ -115,10 +126,7 @@ class LogForwardingPlugin {
         FilterPattern: options.filterPattern,
         LogGroupName: logGroupName,
       },
-      DependsOn: [
-        'LogForwardingLambdaPermission',
-        functionLogGroupId,
-      ],
+      DependsOn: _.union(options.dependsOn, [functionLogGroupId]),
     };
     return filter;
   }

--- a/index.js
+++ b/index.js
@@ -63,10 +63,11 @@ class LogForwardingPlugin {
     const resourceObj = {};
 
     // Only one lambda permission is needed if it is not disabled
-    // The Lambda permission should only be disabled if this plugin is used in numerous (e.g. 70+) serverless projects
-    // that deploy to the same destinationARN within the same AWS account. There is a 20kb function policy limit that may
-    // be exceeded by the destination function policy in this case.
-    // If disabled, the user will be expected to create this lambda permission for the destination function by other means
+    // The Lambda permission should only be disabled if this plugin is used in numerous (e.g. 70+)
+    // serverless projects that deploy to the same destinationARN within the same AWS account.
+    // There is a 20kb function policy limit that may be exceeded by the destination function
+    // policy in this case. If disabled, the user will be expected to create this lambda permission
+    // for the destination function by other means
     if (!disabledLambdaPermission) {
       _.extend(resourceObj, {
         LogForwardingLambdaPermission: {
@@ -107,7 +108,7 @@ class LogForwardingPlugin {
    *                          arn: arn of the lambda to forward to
    *                          filterPattern: filter pattern for the Subscription
    *                          normalizedFilterID: whether to use normalized FuncName as filter ID
-   *                          dependsOn: array of additional CloudFormation template resources the filter should depend on
+   *                          dependsOn: array of additional resources the filter should depend on
    * @return {Object}               SubscriptionFilter
    */
   makeSubscriptionFilter(functionName, options) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-log-forwarding",
-  "version": "1.2.0",
+  "version": "1.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-log-forwarding",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "a serverless plugin to forward logs to given lambda function",
   "main": "index.js",
   "directories": {

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -19,6 +19,10 @@ const correctConfigWithStageFilter = {
   filterPattern: 'Test Pattern',
   stages: ['production'],
 };
+const correctConfigWithDisabledLambdaPermission = {
+  destinationARN: 'arn:aws:lambda:us-moon-1:314159265358:function:testforward-test-forward',
+  disabledLambdaPermission: true,
+};
 
 const Serverless = require('serverless');
 const AwsProvider = require('serverless/lib/plugins/aws/provider/awsProvider');
@@ -368,6 +372,42 @@ describe('Given a serverless config', () => {
       Resources: {
         TestExistingFilter: {
           Type: 'AWS:Test:Filter',
+        },
+      },
+    };
+    plugin.updateResources();
+    expect(plugin.serverless.service.resources).to.eql(expectedResources);
+  });
+
+
+  it('uses the disabledLambdaPermission property if set to not include the LogForwardingLambdaPermission', () => {
+    const plugin = constructPluginResources(correctConfigWithDisabledLambdaPermission);
+    const expectedResources = {
+      Resources: {
+        TestExistingFilter: {
+          Type: 'AWS:Test:Filter',
+        },
+        SubscriptionFilterTestFunctionOne: {
+          Type: 'AWS::Logs::SubscriptionFilter',
+          Properties: {
+            DestinationArn: 'arn:aws:lambda:us-moon-1:314159265358:function:testforward-test-forward',
+            FilterPattern: '',
+            LogGroupName: '/aws/lambda/test-service-test-stage-testFunctionOne',
+          },
+          DependsOn: [
+            'TestFunctionOneLogGroup',
+          ],
+        },
+        SubscriptionFilterTestFunctionTwo: {
+          Type: 'AWS::Logs::SubscriptionFilter',
+          Properties: {
+            DestinationArn: 'arn:aws:lambda:us-moon-1:314159265358:function:testforward-test-forward',
+            FilterPattern: '',
+            LogGroupName: '/aws/lambda/test-service-test-stage-testFunctionTwo',
+          },
+          DependsOn: [
+            'TestFunctionTwoLogGroup',
+          ],
         },
       },
     };


### PR DESCRIPTION
__Background__
My team ran into a breaking issue at scale with this plugin.
We have over 75 separate Serverless project microservices across different repositories.
All of these services use `serverless-log-forwarding` with the same destinationARN.
Our recent attempts at deploying newly created services have failed because we reached `PolicyLengthExceededException` errors when creating the `LogForwardingLambdaPermission`.
We discovered that there is a 20kb limit for the lambda policy of the destination function and that every project that uses `serverless-log-forwarding` appends a functionally identical `AWS::Lambda::Permission` in the existing policy of the destination function (only differing in statement ids).

__Solution__
I added a new `disabledLambdaPermission` option which will not include the creation of a `LogForwardingLambdaPermission` in the CloudFormation template.
When disabled, the user will be expected to create this lambda permission for the destination function by other means. In my case, we added it to the `Resources` section of our destination function's serverless.yml