### PR TITLE
Add role arn functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ custom:
   logForwarding:
     destinationARN: '[ARN of Lambda Function to forward logs to]'
     # optional:
+    roleArn: '[ARN of the IAM role that grants Cloudwatch Logs permissions]'
     filterPattern: '[filter pattern for logs that are sent to Lambda function]'
     normalizedFilterID: true # whether to use normalized function name as filter ID
     stages:

--- a/index.js
+++ b/index.js
@@ -117,13 +117,15 @@ class LogForwardingPlugin {
     filter[filterLogicalId] = {
       Type: 'AWS::Logs::SubscriptionFilter',
       Properties: {
-        RoleArn: options.roleArn,
         DestinationArn: options.arn,
         FilterPattern: options.filterPattern,
         LogGroupName: logGroupName,
       },
       DependsOn: _.union(options.dependsOn, [functionLogGroupId]),
     };
+    if (!(options.roleArn === '')) {
+      filter[filterLogicalId].Properties.RoleArn = options.roleArn;
+    }
 
     return filter;
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-log-forwarding",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2795,7 +2795,8 @@
     "lodash": {
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "dev": true
     },
     "lodash.cond": {
       "version": "4.5.2",

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -21,7 +21,7 @@ const correctConfigWithStageFilter = {
 };
 const correctConfigWithRoleArn = {
   destinationARN: 'arn:aws:lambda:us-moon-1:314159265358:function:testforward-test-forward',
-  roleArn: 'rolearn',
+  roleArn: 'arn:aws:lambda:us-moon-1:314159265358:role/test-iam-role',
   normalizedFilterID: false,
 };
 
@@ -390,37 +390,43 @@ describe('Given a serverless config', () => {
     plugin.updateResources();
     expect(plugin.serverless.service.resources).to.eql(expectedResources);
   });
-});
 
-it('uses the roleArn property if set', () => {
-  const plugin = constructPluginResources(correctConfigWithRoleArn);
-  const expectedResources = {
-    Resources: {
-      TestExistingFilter: {
-        Type: 'AWS:Test:Filter',
-      },
-      SubscriptionFiltertestFunctionOne: {
-        Type: 'AWS::Logs::SubscriptionFilter',
-        Properties: {
-          DestinationArn: 'arn:aws:lambda:us-moon-1:314159265358:function:testforward-test-forward',
-          FilterPattern: '',
-          LogGroupName: '/aws/lambda/test-service-test-stage-testFunctionOne',
-          RoleArn: 'rolearn',
+  it('uses the roleArn property if set', () => {
+    const plugin = constructPluginResources(correctConfigWithRoleArn);
+    const expectedResources = {
+      Resources: {
+        TestExistingFilter: {
+          Type: 'AWS:Test:Filter',
+        },
+        SubscriptionFiltertestFunctionOne: {
+          Type: 'AWS::Logs::SubscriptionFilter',
+          Properties: {
+            DestinationArn: 'arn:aws:lambda:us-moon-1:314159265358:function:testforward-test-forward',
+            FilterPattern: '',
+            LogGroupName: '/aws/lambda/test-service-test-stage-testFunctionOne',
+            RoleArn: 'arn:aws:lambda:us-moon-1:314159265358:role/test-iam-role',
+          },
+          DependsOn: [
+            'TestFunctionOneLogGroup',
+          ],
+        },
+        SubscriptionFiltertestFunctionTwo: {
+          Type: 'AWS::Logs::SubscriptionFilter',
+          Properties: {
+            DestinationArn: 'arn:aws:lambda:us-moon-1:314159265358:function:testforward-test-forward',
+            FilterPattern: '',
+            LogGroupName: '/aws/lambda/test-service-test-stage-testFunctionTwo',
+            RoleArn: 'arn:aws:lambda:us-moon-1:314159265358:role/test-iam-role',
+          },
+          DependsOn: [
+            'TestFunctionTwoLogGroup',
+          ],
         },
       },
-      SubscriptionFiltertestFunctionTwo: {
-        Type: 'AWS::Logs::SubscriptionFilter',
-        Properties: {
-          DestinationArn: 'arn:aws:lambda:us-moon-1:314159265358:function:testforward-test-forward',
-          FilterPattern: '',
-          LogGroupName: '/aws/lambda/test-service-test-stage-testFunctionTwo',
-          RoleArn: 'rolearn',
-        },
-      },
-    },
-  };
-  plugin.updateResources();
-  expect(plugin.serverless.service.resources).to.eql(expectedResources);
+    };
+    plugin.updateResources();
+    expect(plugin.serverless.service.resources).to.eql(expectedResources);
+  });
 });
 
 describe('Catching errors in serverless config ', () => {

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -19,6 +19,11 @@ const correctConfigWithStageFilter = {
   filterPattern: 'Test Pattern',
   stages: ['production'],
 };
+const correctConfigWithRoleArn = {
+  destinationARN: 'arn:aws:lambda:us-moon-1:314159265358:function:testforward-test-forward',
+  roleArn: 'rolearn',
+  normalizedFilterID: false,
+};
 
 const Serverless = require('serverless');
 const AwsProvider = require('serverless/lib/plugins/aws/provider/awsProvider');
@@ -136,6 +141,7 @@ describe('Given a serverless config', () => {
             DestinationArn: 'arn:aws:lambda:us-moon-1:314159265358:function:testforward-test-forward',
             FilterPattern: '',
             LogGroupName: '/aws/lambda/test-service-test-stage-testFunctionOne',
+            RoleArn: '',
           },
           DependsOn: [
             'LogForwardingLambdaPermission',
@@ -148,6 +154,7 @@ describe('Given a serverless config', () => {
             DestinationArn: 'arn:aws:lambda:us-moon-1:314159265358:function:testforward-test-forward',
             FilterPattern: '',
             LogGroupName: '/aws/lambda/test-service-test-stage-testFunctionTwo',
+            RoleArn: '',
           },
           DependsOn: [
             'LogForwardingLambdaPermission',
@@ -180,6 +187,7 @@ describe('Given a serverless config', () => {
             DestinationArn: 'arn:aws:lambda:us-moon-1:314159265358:function:testforward-dev-forward',
             FilterPattern: '',
             LogGroupName: '/aws/lambda/test-service-dev-testFunctionOne',
+            RoleArn: '',
           },
           DependsOn: [
             'LogForwardingLambdaPermission',
@@ -192,6 +200,7 @@ describe('Given a serverless config', () => {
             DestinationArn: 'arn:aws:lambda:us-moon-1:314159265358:function:testforward-dev-forward',
             FilterPattern: '',
             LogGroupName: '/aws/lambda/test-service-dev-testFunctionTwo',
+            RoleArn: '',
           },
           DependsOn: [
             'LogForwardingLambdaPermission',
@@ -221,6 +230,7 @@ describe('Given a serverless config', () => {
             DestinationArn: 'arn:aws:lambda:us-moon-1:314159265358:function:testforward-test-forward',
             FilterPattern: '',
             LogGroupName: '/aws/lambda/test-service-test-stage-testFunctionOne',
+            RoleArn: '',
           },
           DependsOn: [
             'LogForwardingLambdaPermission',
@@ -233,6 +243,7 @@ describe('Given a serverless config', () => {
             DestinationArn: 'arn:aws:lambda:us-moon-1:314159265358:function:testforward-test-forward',
             FilterPattern: '',
             LogGroupName: '/aws/lambda/test-service-test-stage-testFunctionTwo',
+            RoleArn: '',
           },
           DependsOn: [
             'LogForwardingLambdaPermission',
@@ -265,6 +276,7 @@ describe('Given a serverless config', () => {
             DestinationArn: 'arn:aws:lambda:us-moon-1:314159265358:function:testforward-test-forward',
             FilterPattern: 'Test Pattern',
             LogGroupName: '/aws/lambda/test-service-test-stage-testFunctionOne',
+            RoleArn: '',
           },
           DependsOn: [
             'LogForwardingLambdaPermission',
@@ -277,6 +289,7 @@ describe('Given a serverless config', () => {
             DestinationArn: 'arn:aws:lambda:us-moon-1:314159265358:function:testforward-test-forward',
             FilterPattern: 'Test Pattern',
             LogGroupName: '/aws/lambda/test-service-test-stage-testFunctionTwo',
+            RoleArn: '',
           },
           DependsOn: [
             'LogForwardingLambdaPermission',
@@ -326,6 +339,7 @@ describe('Given a serverless config', () => {
             DestinationArn: 'arn:aws:lambda:us-moon-1:314159265358:function:testforward-test-forward',
             FilterPattern: 'Test Pattern',
             LogGroupName: '/aws/lambda/test-service-test-stage-testFunctionOne',
+            RoleArn: '',
           },
           DependsOn: [
             'LogForwardingLambdaPermission',
@@ -338,6 +352,7 @@ describe('Given a serverless config', () => {
             DestinationArn: 'arn:aws:lambda:us-moon-1:314159265358:function:testforward-test-forward',
             FilterPattern: 'Test Pattern',
             LogGroupName: '/aws/lambda/test-service-test-stage-testFunctionTwo',
+            RoleArn: '',
           },
           DependsOn: [
             'LogForwardingLambdaPermission',
@@ -350,6 +365,7 @@ describe('Given a serverless config', () => {
             DestinationArn: 'arn:aws:lambda:us-moon-1:314159265358:function:testforward-test-forward',
             FilterPattern: 'Test Pattern',
             LogGroupName: '/aws/lambda/test-service-test-stage-testFunctionThree',
+            RoleArn: '',
           },
           DependsOn: [
             'LogForwardingLambdaPermission',
@@ -374,6 +390,37 @@ describe('Given a serverless config', () => {
     plugin.updateResources();
     expect(plugin.serverless.service.resources).to.eql(expectedResources);
   });
+});
+
+it('uses the roleArn property if set', () => {
+  const plugin = constructPluginResources(correctConfigWithRoleArn);
+  const expectedResources = {
+    Resources: {
+      TestExistingFilter: {
+        Type: 'AWS:Test:Filter',
+      },
+      SubscriptionFiltertestFunctionOne: {
+        Type: 'AWS::Logs::SubscriptionFilter',
+        Properties: {
+          DestinationArn: 'arn:aws:lambda:us-moon-1:314159265358:function:testforward-test-forward',
+          FilterPattern: '',
+          LogGroupName: '/aws/lambda/test-service-test-stage-testFunctionOne',
+          RoleArn: 'rolearn',
+        },
+      },
+      SubscriptionFiltertestFunctionTwo: {
+        Type: 'AWS::Logs::SubscriptionFilter',
+        Properties: {
+          DestinationArn: 'arn:aws:lambda:us-moon-1:314159265358:function:testforward-test-forward',
+          FilterPattern: '',
+          LogGroupName: '/aws/lambda/test-service-test-stage-testFunctionTwo',
+          RoleArn: 'rolearn',
+        },
+      },
+    },
+  };
+  plugin.updateResources();
+  expect(plugin.serverless.service.resources).to.eql(expectedResources);
 });
 
 describe('Catching errors in serverless config ', () => {

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -141,7 +141,6 @@ describe('Given a serverless config', () => {
             DestinationArn: 'arn:aws:lambda:us-moon-1:314159265358:function:testforward-test-forward',
             FilterPattern: '',
             LogGroupName: '/aws/lambda/test-service-test-stage-testFunctionOne',
-            RoleArn: '',
           },
           DependsOn: [
             'LogForwardingLambdaPermission',
@@ -154,7 +153,6 @@ describe('Given a serverless config', () => {
             DestinationArn: 'arn:aws:lambda:us-moon-1:314159265358:function:testforward-test-forward',
             FilterPattern: '',
             LogGroupName: '/aws/lambda/test-service-test-stage-testFunctionTwo',
-            RoleArn: '',
           },
           DependsOn: [
             'LogForwardingLambdaPermission',
@@ -187,7 +185,6 @@ describe('Given a serverless config', () => {
             DestinationArn: 'arn:aws:lambda:us-moon-1:314159265358:function:testforward-dev-forward',
             FilterPattern: '',
             LogGroupName: '/aws/lambda/test-service-dev-testFunctionOne',
-            RoleArn: '',
           },
           DependsOn: [
             'LogForwardingLambdaPermission',
@@ -200,7 +197,6 @@ describe('Given a serverless config', () => {
             DestinationArn: 'arn:aws:lambda:us-moon-1:314159265358:function:testforward-dev-forward',
             FilterPattern: '',
             LogGroupName: '/aws/lambda/test-service-dev-testFunctionTwo',
-            RoleArn: '',
           },
           DependsOn: [
             'LogForwardingLambdaPermission',
@@ -230,7 +226,6 @@ describe('Given a serverless config', () => {
             DestinationArn: 'arn:aws:lambda:us-moon-1:314159265358:function:testforward-test-forward',
             FilterPattern: '',
             LogGroupName: '/aws/lambda/test-service-test-stage-testFunctionOne',
-            RoleArn: '',
           },
           DependsOn: [
             'LogForwardingLambdaPermission',
@@ -243,7 +238,6 @@ describe('Given a serverless config', () => {
             DestinationArn: 'arn:aws:lambda:us-moon-1:314159265358:function:testforward-test-forward',
             FilterPattern: '',
             LogGroupName: '/aws/lambda/test-service-test-stage-testFunctionTwo',
-            RoleArn: '',
           },
           DependsOn: [
             'LogForwardingLambdaPermission',
@@ -276,7 +270,6 @@ describe('Given a serverless config', () => {
             DestinationArn: 'arn:aws:lambda:us-moon-1:314159265358:function:testforward-test-forward',
             FilterPattern: 'Test Pattern',
             LogGroupName: '/aws/lambda/test-service-test-stage-testFunctionOne',
-            RoleArn: '',
           },
           DependsOn: [
             'LogForwardingLambdaPermission',
@@ -289,7 +282,6 @@ describe('Given a serverless config', () => {
             DestinationArn: 'arn:aws:lambda:us-moon-1:314159265358:function:testforward-test-forward',
             FilterPattern: 'Test Pattern',
             LogGroupName: '/aws/lambda/test-service-test-stage-testFunctionTwo',
-            RoleArn: '',
           },
           DependsOn: [
             'LogForwardingLambdaPermission',
@@ -339,7 +331,6 @@ describe('Given a serverless config', () => {
             DestinationArn: 'arn:aws:lambda:us-moon-1:314159265358:function:testforward-test-forward',
             FilterPattern: 'Test Pattern',
             LogGroupName: '/aws/lambda/test-service-test-stage-testFunctionOne',
-            RoleArn: '',
           },
           DependsOn: [
             'LogForwardingLambdaPermission',
@@ -352,7 +343,6 @@ describe('Given a serverless config', () => {
             DestinationArn: 'arn:aws:lambda:us-moon-1:314159265358:function:testforward-test-forward',
             FilterPattern: 'Test Pattern',
             LogGroupName: '/aws/lambda/test-service-test-stage-testFunctionTwo',
-            RoleArn: '',
           },
           DependsOn: [
             'LogForwardingLambdaPermission',
@@ -365,7 +355,6 @@ describe('Given a serverless config', () => {
             DestinationArn: 'arn:aws:lambda:us-moon-1:314159265358:function:testforward-test-forward',
             FilterPattern: 'Test Pattern',
             LogGroupName: '/aws/lambda/test-service-test-stage-testFunctionThree',
-            RoleArn: '',
           },
           DependsOn: [
             'LogForwardingLambdaPermission',


### PR DESCRIPTION
Adds a roleArn option to the Serverless yaml which allows the user to forward logs to non-lambda subscription filters such as AWS Kinesis Streams