### PR TITLE
Add option to disable creation of AWS::Lambda::Permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ custom:
     roleArn: '[ARN of the IAM role that grants Cloudwatch Logs permissions]'
     filterPattern: '[filter pattern for logs that are sent to Lambda function]'
     normalizedFilterID: true # whether to use normalized function name as filter ID
+    disablePermissionCreation: false # whether to disable the creation of a AWS::Lambda::Permission resource to allow AWS to invoke your subscription lambda
     stages:
       - '[name of the stage to apply log forwarding]'
       - '[another stage name to filter]'

--- a/index.js
+++ b/index.js
@@ -55,6 +55,7 @@ class LogForwardingPlugin {
     const filterPattern = service.custom.logForwarding.filterPattern || '';
     const normalizedFilterID = !(service.custom.logForwarding.normalizedFilterID === false);
     const roleArn = service.custom.logForwarding.roleArn || '';
+    const disablePermissionCreation = service.custom.logForwarding.disablePermissionCreation || false;
     // Get options and parameters to make resources object
     const arn = service.custom.logForwarding.destinationARN;
     // Get list of all functions in this lambda
@@ -62,7 +63,7 @@ class LogForwardingPlugin {
     // Generate resources object for each function
     // Only one lambda permission is needed
     const resourceObj = {};
-    if (!roleArn) {
+    if (!roleArn && !disablePermissionCreation) {
       _.extend(resourceObj, {
         LogForwardingLambdaPermission: {
           Type: 'AWS::Lambda::Permission',
@@ -88,7 +89,7 @@ class LogForwardingPlugin {
           filterPattern,
           normalizedFilterID,
           roleArn,
-          dependsOn: (roleArn === '') ? ['LogForwardingLambdaPermission'] : [],
+          dependsOn: (roleArn === '' && !disablePermissionCreation) ? ['LogForwardingLambdaPermission'] : [],
         });
         /* merge new SubscriptionFilter with current resources object */
         _.extend(resourceObj, subscriptionFilter);

--- a/index.js
+++ b/index.js
@@ -55,7 +55,8 @@ class LogForwardingPlugin {
     const filterPattern = service.custom.logForwarding.filterPattern || '';
     const normalizedFilterID = !(service.custom.logForwarding.normalizedFilterID === false);
     const roleArn = service.custom.logForwarding.roleArn || '';
-    const disablePermissionCreation = service.custom.logForwarding.disablePermissionCreation || false;
+    const disablePermissionCreation =
+      service.custom.logForwarding.disablePermissionCreation || false;
     // Get options and parameters to make resources object
     const arn = service.custom.logForwarding.destinationARN;
     // Get list of all functions in this lambda

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -24,6 +24,10 @@ const correctConfigWithRoleArn = {
   roleArn: 'arn:aws:lambda:us-moon-1:314159265358:role/test-iam-role',
   normalizedFilterID: false,
 };
+const correctConfigWithDisablePermissionCreation = {
+  destinationARN: 'arn:aws:lambda:us-moon-1:314159265358:function:testforward-test-forward',
+  disablePermissionCreation: true,
+};
 
 const Serverless = require('serverless');
 const AwsProvider = require('serverless/lib/plugins/aws/provider/awsProvider');
@@ -406,6 +410,38 @@ describe('Given a serverless config', () => {
             FilterPattern: '',
             LogGroupName: '/aws/lambda/test-service-test-stage-testFunctionTwo',
             RoleArn: 'arn:aws:lambda:us-moon-1:314159265358:role/test-iam-role',
+          },
+          DependsOn: [
+            'TestFunctionTwoLogGroup',
+          ],
+        },
+      },
+    };
+    plugin.updateResources();
+    expect(plugin.serverless.service.resources).to.eql(expectedResources);
+  });
+
+  it('Skips creation of AWS::Lambda::Permission if configured so', () => {
+    const plugin = constructPluginNoResources(correctConfigWithDisablePermissionCreation);
+    const expectedResources = {
+      Resources: {
+        SubscriptionFilterTestFunctionOne: {
+          Type: 'AWS::Logs::SubscriptionFilter',
+          Properties: {
+            DestinationArn: 'arn:aws:lambda:us-moon-1:314159265358:function:testforward-test-forward',
+            FilterPattern: '',
+            LogGroupName: '/aws/lambda/test-service-test-stage-testFunctionOne',
+          },
+          DependsOn: [
+            'TestFunctionOneLogGroup',
+          ],
+        },
+        SubscriptionFilterTestFunctionTwo: {
+          Type: 'AWS::Logs::SubscriptionFilter',
+          Properties: {
+            DestinationArn: 'arn:aws:lambda:us-moon-1:314159265358:function:testforward-test-forward',
+            FilterPattern: '',
+            LogGroupName: '/aws/lambda/test-service-test-stage-testFunctionTwo',
           },
           DependsOn: [
             'TestFunctionTwoLogGroup',


### PR DESCRIPTION
When there are a large number of permissions already added to the lambda and this plugin was adding an additional one, we were getting this error from cloudformation:

```
  | CREATE_FAILED | AWS::Lambda::Permission | LogForwardingLambdaPermission | The  final policy size (20588) is bigger than the limit (20480). (Service:  AWSLambda; Status Code: 400; Error Code: PolicyLengthExceededException;  Request ID: xxx)
-- | -- | -- | -- | --
```

I think that the creation of the permission for AWS Logs to invoke the subscriber lambda should be managed by whatever deploys that lambda which would prevent this issue from happening.  This PR adds the configuration that allows for that option.

