### PR TITLE
Add support for disabledLambdaPermission option when policy size limits are a concern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+
+## [1.4.0] - 2019-03-17
+
+### Added
+
+- Added support for disabling automatic creation of a AWS::Lambda::Permission. createLambdaPermission flag is enabled by default.
+
+
 ## [1.3.0] - 2018-12-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ custom:
     stages:
       - '[name of the stage to apply log forwarding]'
       - '[another stage name to filter]'
-    disabledLambdaPermission: false # whether to disable creation of the AWS::Lambda::Permission for the destinationARN (when policy size limits are a concern)
+    createLambdaPermission: true # whether to create the AWS::Lambda::Permission for the destinationARN (when policy size limits are a concern)
 
 functions:
   myFunction:

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ custom:
     stages:
       - '[name of the stage to apply log forwarding]'
       - '[another stage name to filter]'
+    disabledLambdaPermission: false # whether to disable creation of the AWS::Lambda::Permission for the destinationARN (when policy size limits are a concern)
 
 functions:
   myFunction:

--- a/index.js
+++ b/index.js
@@ -55,14 +55,20 @@ class LogForwardingPlugin {
     const filterPattern = service.custom.logForwarding.filterPattern || '';
     const normalizedFilterID = !(service.custom.logForwarding.normalizedFilterID === false);
     const roleArn = service.custom.logForwarding.roleArn || '';
+    const disabledLambdaPermission = service.custom.logForwarding.disabledLambdaPermission === true;
     // Get options and parameters to make resources object
     const arn = service.custom.logForwarding.destinationARN;
     // Get list of all functions in this lambda
     const principal = `logs.${service.provider.region}.amazonaws.com`;
     // Generate resources object for each function
-    // Only one lambda permission is needed
+    // Only one lambda permission is needed if it is not disabled
     const resourceObj = {};
     if (!roleArn) {
+        // The Lambda permission should only be disabled if this plugin is used in numerous (e.g. 70+) serverless projects
+        // that deploy to the same destinationARN within the same AWS account. There is a 20kb function policy limit that may
+        // be exceeded by the destination function policy in this case.
+        // If disabled, the user will be expected to create this lambda permission for the destination function by other means
+        if (!disabledLambdaPermission) {
       _.extend(resourceObj, {
         LogForwardingLambdaPermission: {
           Type: 'AWS::Lambda::Permission',
@@ -88,7 +94,7 @@ class LogForwardingPlugin {
           filterPattern,
           normalizedFilterID,
           roleArn,
-          dependsOn: (roleArn === '') ? ['LogForwardingLambdaPermission'] : [],
+          dependsOn: (roleArn === '' && ! disabledLambdaPermission) ? ['LogForwardingLambdaPermission'] : [],
         });
         /* merge new SubscriptionFilter with current resources object */
         _.extend(resourceObj, subscriptionFilter);
@@ -103,6 +109,7 @@ class LogForwardingPlugin {
    *                          arn: arn of the lambda to forward to
    *                          filterPattern: filter pattern for the Subscription
    *                          normalizedFilterID: whether to use normalized FuncName as filter ID
+   *                          dependsOn: array of additional CloudFormation template resources the filter should depend on
    * @return {Object}               SubscriptionFilter
    */
   makeSubscriptionFilter(functionName, options) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-log-forwarding",
-  "version": "1.2.1",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -124,22 +124,12 @@
       "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
       "dev": true
     },
-    "align-text": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "dev": true,
-      "requires": {
-        "kind-of": "^3.0.2",
-        "longest": "^1.0.1",
-        "repeat-string": "^1.5.2"
-      }
-    },
     "amdefine": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "ansi": {
       "version": "0.3.1",
@@ -678,13 +668,6 @@
       "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
       "dev": true
     },
-    "camelcase": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-      "dev": true,
-      "optional": true
-    },
     "capture-stack-trace": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
@@ -701,17 +684,6 @@
         "isurl": "^1.0.0-alpha5",
         "tunnel-agent": "^0.6.0",
         "url-to-options": "^1.0.1"
-      }
-    },
-    "center-align": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "align-text": "^0.1.3",
-        "lazy-cache": "^1.0.3"
       }
     },
     "chai": {
@@ -770,27 +742,6 @@
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
       "integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao=",
       "dev": true
-    },
-    "cliui": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "center-align": "^0.1.1",
-        "right-align": "^0.1.1",
-        "wordwrap": "0.0.2"
-      },
-      "dependencies": {
-        "wordwrap": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-          "dev": true,
-          "optional": true
-        }
-      }
     },
     "co": {
       "version": "4.6.0",
@@ -1019,13 +970,6 @@
       "requires": {
         "ms": "2.0.0"
       }
-    },
-    "decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "dev": true,
-      "optional": true
     },
     "decompress": {
       "version": "4.2.0",
@@ -2135,25 +2079,31 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
-      "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.0.tgz",
+      "integrity": "sha512-l2jRuU1NAWK6AW5qqcTATWQJvNPEwkM7NEKSiv/gqOsoSQbVoWyqVEY5GS+XPQ88zLNmqASRpzfdm8d79hJS+w==",
       "dev": true,
       "requires": {
-        "async": "^1.4.0",
+        "async": "^2.5.0",
         "optimist": "^0.6.1",
-        "source-map": "^0.4.4",
-        "uglify-js": "^2.6"
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4"
       },
       "dependencies": {
-        "source-map": {
-          "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+        "async": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
+          "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
           "dev": true,
           "requires": {
-            "amdefine": ">=0.0.4"
+            "lodash": "^4.17.11"
           }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
         }
       }
     },
@@ -2345,12 +2295,6 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-      "dev": true
-    },
-    "is-buffer": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
       "dev": true
     },
     "is-builtin-module": {
@@ -2709,15 +2653,6 @@
       "integrity": "sha1-fYa9VmefWM5qhHBKZX3TkruoGnk=",
       "dev": true
     },
-    "kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "dev": true,
-      "requires": {
-        "is-buffer": "^1.1.5"
-      }
-    },
     "klaw": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
@@ -2735,13 +2670,6 @@
       "requires": {
         "package-json": "^4.0.0"
       }
-    },
-    "lazy-cache": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-      "dev": true,
-      "optional": true
     },
     "lazystream": {
       "version": "1.0.0",
@@ -2832,12 +2760,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
-      "dev": true
-    },
-    "longest": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
       "dev": true
     },
     "lowercase-keys": {
@@ -3600,12 +3522,6 @@
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
       "dev": true
     },
-    "repeat-string": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "dev": true
-    },
     "replaceall": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/replaceall/-/replaceall-0.1.6.tgz",
@@ -3645,16 +3561,6 @@
       "requires": {
         "exit-hook": "^1.0.0",
         "onetime": "^1.0.0"
-      }
-    },
-    "right-align": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "align-text": "^0.1.1"
       }
     },
     "rimraf": {
@@ -4380,32 +4286,31 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "2.8.29",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+      "version": "3.4.9",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
+      "integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
       "dev": true,
       "optional": true,
       "requires": {
-        "source-map": "~0.5.1",
-        "uglify-to-browserify": "~1.0.0",
-        "yargs": "~3.10.0"
+        "commander": "~2.17.1",
+        "source-map": "~0.6.1"
       },
       "dependencies": {
+        "commander": {
+          "version": "2.17.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+          "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
+          "dev": true,
+          "optional": true
+        },
         "source-map": {
-          "version": "0.5.6",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true,
           "optional": true
         }
       }
-    },
-    "uglify-to-browserify": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-      "dev": true,
-      "optional": true
     },
     "unbzip2-stream": {
       "version": "1.3.1",
@@ -4665,13 +4570,6 @@
         }
       }
     },
-    "window-size": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-      "dev": true,
-      "optional": true
-    },
     "wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
@@ -4743,19 +4641,6 @@
       "resolved": "https://registry.npmjs.org/yaml-ast-parser/-/yaml-ast-parser-0.0.34.tgz",
       "integrity": "sha1-0A88+ddztyQUCa6SpnQNHbGfSeY=",
       "dev": true
-    },
-    "yargs": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-      "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "camelcase": "^1.0.2",
-        "cliui": "^2.1.0",
-        "decamelize": "^1.0.0",
-        "window-size": "0.1.0"
-      }
     },
     "yauzl": {
       "version": "2.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-log-forwarding",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "a serverless plugin to forward logs to given lambda function",
   "main": "index.js",
   "directories": {

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -19,23 +19,26 @@ const correctConfigWithStageFilter = {
   filterPattern: 'Test Pattern',
   stages: ['production'],
 };
-const correctConfigWithRoleArn = {
-const correctConfigWithRoleArn = {
-const correctConfigWithDisabledLambdaPermission = {
-  destinationARN: 'arn:aws:lambda:us-moon-1:314159265358:function:testforward-test-forward',
-  roleArn: 'arn:aws:lambda:us-moon-1:314159265358:role/test-iam-role',
-  normalizedFilterID: false,
-  disabledLambdaPermission: true,
-};
+
 const correctConfigWithRoleArn = {
   destinationARN: 'arn:aws:lambda:us-moon-1:314159265358:function:testforward-test-forward',
   roleArn: 'arn:aws:lambda:us-moon-1:314159265358:role/test-iam-role',
   normalizedFilterID: false,
 };
+
 const correctConfigWithDisabledLambdaPermission = {
   destinationARN: 'arn:aws:lambda:us-moon-1:314159265358:function:testforward-test-forward',
-  disabledLambdaPermission: true,
+  normalizedFilterID: false,
+  createLambdaPermission: false,
 };
+
+const correctConfigWithDisabledLambdaPermissionAndRoleArn = {
+  destinationARN: 'arn:aws:lambda:us-moon-1:314159265358:function:testforward-test-forward',
+  roleArn: 'arn:aws:lambda:us-moon-1:314159265358:role/test-iam-role',
+  normalizedFilterID: false,
+  createLambdaPermission: false,
+};
+
 
 const Serverless = require('serverless');
 const AwsProvider = require('serverless/lib/plugins/aws/provider/awsProvider');
@@ -305,7 +308,6 @@ describe('Given a serverless config', () => {
     plugin.updateResources();
     expect(plugin.serverless.service.resources).to.eql(expectedResources);
   });
-
   it('excludes functions with logForwarding.enabled=false from AWS::Logs::SubscriptionFilter output', () => {
     const plugin = constructPluginResources(correctConfigWithFilterPattern, {
       testFunctionOne: {
@@ -378,7 +380,6 @@ describe('Given a serverless config', () => {
     plugin.updateResources();
     expect(plugin.serverless.service.resources).to.eql(expectedResources);
   });
-
   it('uses stage filter if set', () => {
     const plugin = constructPluginResources(correctConfigWithStageFilter);
     const expectedResources = {
@@ -391,8 +392,43 @@ describe('Given a serverless config', () => {
     plugin.updateResources();
     expect(plugin.serverless.service.resources).to.eql(expectedResources);
   });
+  it('uses the roleArn property if set', () => {
+    const plugin = constructPluginResources(correctConfigWithRoleArn);
 
-
+    const expectedResources = {
+      Resources: {
+        TestExistingFilter: {
+          Type: 'AWS:Test:Filter',
+        },
+        SubscriptionFiltertestFunctionOne: {
+          Type: 'AWS::Logs::SubscriptionFilter',
+          Properties: {
+            DestinationArn: 'arn:aws:lambda:us-moon-1:314159265358:function:testforward-test-forward',
+            FilterPattern: '',
+            LogGroupName: '/aws/lambda/test-service-test-stage-testFunctionOne',
+            RoleArn: 'arn:aws:lambda:us-moon-1:314159265358:role/test-iam-role',
+          },
+          DependsOn: [
+            'TestFunctionOneLogGroup',
+          ],
+        },
+        SubscriptionFiltertestFunctionTwo: {
+          Type: 'AWS::Logs::SubscriptionFilter',
+          Properties: {
+            DestinationArn: 'arn:aws:lambda:us-moon-1:314159265358:function:testforward-test-forward',
+            FilterPattern: '',
+            LogGroupName: '/aws/lambda/test-service-test-stage-testFunctionTwo',
+            RoleArn: 'arn:aws:lambda:us-moon-1:314159265358:role/test-iam-role',
+          },
+          DependsOn: [
+            'TestFunctionTwoLogGroup',
+          ],
+        },
+      },
+    };
+    plugin.updateResources();
+    expect(plugin.serverless.service.resources).to.eql(expectedResources);
+  });
   it('uses the disabledLambdaPermission property if set to not include the LogForwardingLambdaPermission', () => {
     const plugin = constructPluginResources(correctConfigWithDisabledLambdaPermission);
     const expectedResources = {
@@ -400,7 +436,7 @@ describe('Given a serverless config', () => {
         TestExistingFilter: {
           Type: 'AWS:Test:Filter',
         },
-        SubscriptionFilterTestFunctionOne: {
+        SubscriptionFiltertestFunctionOne: {
           Type: 'AWS::Logs::SubscriptionFilter',
           Properties: {
             DestinationArn: 'arn:aws:lambda:us-moon-1:314159265358:function:testforward-test-forward',
@@ -411,7 +447,7 @@ describe('Given a serverless config', () => {
             'TestFunctionOneLogGroup',
           ],
         },
-        SubscriptionFilterTestFunctionTwo: {
+        SubscriptionFiltertestFunctionTwo: {
           Type: 'AWS::Logs::SubscriptionFilter',
           Properties: {
             DestinationArn: 'arn:aws:lambda:us-moon-1:314159265358:function:testforward-test-forward',
@@ -427,31 +463,32 @@ describe('Given a serverless config', () => {
     plugin.updateResources();
     expect(plugin.serverless.service.resources).to.eql(expectedResources);
   });
-  
-    it('uses the disabledLambdaPermission property if set to not include the LogForwardingLambdaPermission', () => {
-    const plugin = constructPluginResources(correctConfigWithDisabledLambdaPermission);
+  it('uses the roleArn even if disabledLambdaPermission property is set', () => {
+    const plugin = constructPluginResources(correctConfigWithDisabledLambdaPermissionAndRoleArn);
     const expectedResources = {
       Resources: {
         TestExistingFilter: {
           Type: 'AWS:Test:Filter',
         },
-        SubscriptionFilterTestFunctionOne: {
+        SubscriptionFiltertestFunctionOne: {
           Type: 'AWS::Logs::SubscriptionFilter',
           Properties: {
             DestinationArn: 'arn:aws:lambda:us-moon-1:314159265358:function:testforward-test-forward',
             FilterPattern: '',
             LogGroupName: '/aws/lambda/test-service-test-stage-testFunctionOne',
+            RoleArn: 'arn:aws:lambda:us-moon-1:314159265358:role/test-iam-role',
           },
           DependsOn: [
             'TestFunctionOneLogGroup',
           ],
         },
-        SubscriptionFilterTestFunctionTwo: {
+        SubscriptionFiltertestFunctionTwo: {
           Type: 'AWS::Logs::SubscriptionFilter',
           Properties: {
             DestinationArn: 'arn:aws:lambda:us-moon-1:314159265358:function:testforward-test-forward',
             FilterPattern: '',
             LogGroupName: '/aws/lambda/test-service-test-stage-testFunctionTwo',
+            RoleArn: 'arn:aws:lambda:us-moon-1:314159265358:role/test-iam-role',
           },
           DependsOn: [
             'TestFunctionTwoLogGroup',

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -20,9 +20,21 @@ const correctConfigWithStageFilter = {
   stages: ['production'],
 };
 const correctConfigWithRoleArn = {
+const correctConfigWithRoleArn = {
+const correctConfigWithDisabledLambdaPermission = {
   destinationARN: 'arn:aws:lambda:us-moon-1:314159265358:function:testforward-test-forward',
   roleArn: 'arn:aws:lambda:us-moon-1:314159265358:role/test-iam-role',
   normalizedFilterID: false,
+  disabledLambdaPermission: true,
+};
+const correctConfigWithRoleArn = {
+  destinationARN: 'arn:aws:lambda:us-moon-1:314159265358:function:testforward-test-forward',
+  roleArn: 'arn:aws:lambda:us-moon-1:314159265358:role/test-iam-role',
+  normalizedFilterID: false,
+};
+const correctConfigWithDisabledLambdaPermission = {
+  destinationARN: 'arn:aws:lambda:us-moon-1:314159265358:function:testforward-test-forward',
+  disabledLambdaPermission: true,
 };
 
 const Serverless = require('serverless');
@@ -380,32 +392,66 @@ describe('Given a serverless config', () => {
     expect(plugin.serverless.service.resources).to.eql(expectedResources);
   });
 
-  it('uses the roleArn property if set', () => {
-    const plugin = constructPluginResources(correctConfigWithRoleArn);
+
+  it('uses the disabledLambdaPermission property if set to not include the LogForwardingLambdaPermission', () => {
+    const plugin = constructPluginResources(correctConfigWithDisabledLambdaPermission);
     const expectedResources = {
       Resources: {
         TestExistingFilter: {
           Type: 'AWS:Test:Filter',
         },
-        SubscriptionFiltertestFunctionOne: {
+        SubscriptionFilterTestFunctionOne: {
           Type: 'AWS::Logs::SubscriptionFilter',
           Properties: {
             DestinationArn: 'arn:aws:lambda:us-moon-1:314159265358:function:testforward-test-forward',
             FilterPattern: '',
             LogGroupName: '/aws/lambda/test-service-test-stage-testFunctionOne',
-            RoleArn: 'arn:aws:lambda:us-moon-1:314159265358:role/test-iam-role',
           },
           DependsOn: [
             'TestFunctionOneLogGroup',
           ],
         },
-        SubscriptionFiltertestFunctionTwo: {
+        SubscriptionFilterTestFunctionTwo: {
           Type: 'AWS::Logs::SubscriptionFilter',
           Properties: {
             DestinationArn: 'arn:aws:lambda:us-moon-1:314159265358:function:testforward-test-forward',
             FilterPattern: '',
             LogGroupName: '/aws/lambda/test-service-test-stage-testFunctionTwo',
-            RoleArn: 'arn:aws:lambda:us-moon-1:314159265358:role/test-iam-role',
+          },
+          DependsOn: [
+            'TestFunctionTwoLogGroup',
+          ],
+        },
+      },
+    };
+    plugin.updateResources();
+    expect(plugin.serverless.service.resources).to.eql(expectedResources);
+  });
+  
+    it('uses the disabledLambdaPermission property if set to not include the LogForwardingLambdaPermission', () => {
+    const plugin = constructPluginResources(correctConfigWithDisabledLambdaPermission);
+    const expectedResources = {
+      Resources: {
+        TestExistingFilter: {
+          Type: 'AWS:Test:Filter',
+        },
+        SubscriptionFilterTestFunctionOne: {
+          Type: 'AWS::Logs::SubscriptionFilter',
+          Properties: {
+            DestinationArn: 'arn:aws:lambda:us-moon-1:314159265358:function:testforward-test-forward',
+            FilterPattern: '',
+            LogGroupName: '/aws/lambda/test-service-test-stage-testFunctionOne',
+          },
+          DependsOn: [
+            'TestFunctionOneLogGroup',
+          ],
+        },
+        SubscriptionFilterTestFunctionTwo: {
+          Type: 'AWS::Logs::SubscriptionFilter',
+          Properties: {
+            DestinationArn: 'arn:aws:lambda:us-moon-1:314159265358:function:testforward-test-forward',
+            FilterPattern: '',
+            LogGroupName: '/aws/lambda/test-service-test-stage-testFunctionTwo',
           },
           DependsOn: [
             'TestFunctionTwoLogGroup',


### PR DESCRIPTION
NOTE:
This is based on PR #22, reworked onto current master and with the flag renamed to avoid double negatives (Original idea and code from aliatsis).

Addresses issues GH-25 and GH-26

Background
When using serverless-log-forwarding with the same destinationARN in multiple projects you can run into PolicyLengthExceededException errors due to the 20kb limit for IAM policy size hard limit. This is caused by serverless-log-forwarding appending a functionally identical AWS::Lambda::Permission in the existing policy of the destination function (only differing in statement id, where cloudformation appends a random suffix).

Solution
To add a new disabledLambdaPermission option which will exclude the creation of a LogForwardingLambdaPermission in the CloudFormation template.
When disabled, the user will be expected to create this lambda permission for the destination function by other means eg. via the Resources section of serverless.yml or separate terraform scripts.