### PR TITLE
Implement property schema validation

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,7 @@ export interface SlsFunction {
   name: string;
   logForwarding?: {
     enabled?: boolean;
-  }
+  };
 }
 
 export interface PluginConfig {
@@ -14,34 +14,91 @@ export interface PluginConfig {
   destinationARN: string;
 }
 
+/**
+ * If your plugin adds new properties to any level in the serverless.yml
+ * you can use these functions to add JSON ajv based schema validation for
+ * those properties
+ *
+ * @see https://www.serverless.com/framework/docs/guides/plugins/custom-configuration
+ */
+export interface ConfigSchemaHandler {
+  /**
+   * If your plugin requires additional top-level properties (like provider, custom, service...)
+   * you can use the defineTopLevelProperty helper to add their definition.
+   * @see https://www.serverless.com/framework/docs/guides/plugins/custom-configuration#top-level-properties-via-definetoplevelproperty
+   */
+  defineTopLevelProperty(
+    providerName: string,
+    schema: Record<string, unknown>
+  ): void;
+  /**
+   * If your plugin depends on properties defined in the custom: section, you can use the
+   * defineCustomProperties helper
+   * @see https://www.serverless.com/framework/docs/guides/plugins/custom-configuration#properties-in-custom-via-definecustomproperties
+   */
+  defineCustomProperties(jsonSchema: object): void;
+  /**
+   * If your plugin adds support to a new function event, you can use the
+   * defineFunctionEvent helper
+   * @see https://www.serverless.com/framework/docs/guides/plugins/custom-configuration#function-events-via-definefunctionevent
+   */
+  defineFunctionEvent(
+    providerName: string,
+    event: string,
+    jsonSchema: Record<string, object>
+  ): void;
+  /**
+   * If your plugin adds new properties to a function event, you can use the
+   * defineFunctionEventProperties helper
+   * @see https://www.serverless.com/framework/docs/guides/plugins/custom-configuration#function-event-properties-via-definefunctioneventproperties
+   */
+  defineFunctionEventProperties(
+    providerName: string,
+    existingEvent: string,
+    jsonSchema: object
+  ): void;
+  /**
+   * If your plugin adds new properties to functions, you can use the
+   * defineFunctionProperties helper.
+   * @see https://www.serverless.com/framework/docs/guides/plugins/custom-configuration#function-properties-via-definefunctionproperties
+   */
+  defineFunctionProperties(providerName: string, schema: object): void;
+  /**
+   * If your plugin provides support for a new provider, register it via defineProvider
+   * @see https://www.serverless.com/framework/docs/guides/plugins/custom-configuration#new-provider-via-defineprovider
+   */
+  defineProvider(providerName: string, options?: Record<string, unknown>): void;
+}
+
 export interface ServerlessInstance {
   service: {
-    service: string
+    service: string;
     resources: {
-      Resources: ResourcesCF
-    },
+      Resources: ResourcesCF;
+    };
     provider: {
-      stage: string,
-      region: string
-    },
+      stage: string;
+      region: string;
+    };
     functions: {
       name: unknown[];
-    },
-    getFunction (name: string): SlsFunction,
+    };
+    getFunction(name: string): SlsFunction;
     custom: {
-      logForwarding: PluginConfig
-    },
-  },
+      logForwarding: PluginConfig;
+    };
+  };
   providers: {
     aws: {
-      getRegion (): string,
-    },
-  },
-  getProvider (name: string): AWSProvider,
+      getRegion(): string;
+    };
+  };
+  getProvider(name: string): AWSProvider;
+  configSchemaHandler: ConfigSchemaHandler;
   cli: {
-    log (str: string, entity?: string): void,
-    consoleLog (str: string): void,
-  }
+    log(str: string, entity?: string): void;
+    consoleLog(str: string): void;
+  };
 }
 
 export interface ServerlessConfig {
@@ -52,10 +109,10 @@ export interface ServerlessConfig {
 
 export interface AWSProvider {
   naming: {
-    getLogGroupName(name: string): string,
-    getNormalizedFunctionName(name: string): string,
-    getLogGroupLogicalId(name: string): string
-  }
+    getLogGroupName(name: string): string;
+    getNormalizedFunctionName(name: string): string;
+    getLogGroupLogicalId(name: string): string;
+  };
 }
 
 export interface ObjectCF<TProps> {

--- a/test/unit-tests/index-test.ts
+++ b/test/unit-tests/index-test.ts
@@ -58,11 +58,12 @@ const constructPluginResources = (logForwarding, functions?) => {
   const config = {
     commands: [],
     options: {},
+    stage: 'test-stage',
   };
   const serverless = createServerless(config, {
     provider: {
       region: 'us-moon-1',
-      stage: 'test-stage',
+      stage: config.stage,
     },
     custom: {
       logForwarding,
@@ -89,11 +90,12 @@ const constructPluginNoResources = (logForwarding) => {
   const config = {
     commands: [],
     options: {},
+    stage: 'test-stage',
   };
   const serverless = createServerless(config, {
     provider: {
       region: 'us-moon-1',
-      stage: 'test-stage',
+      stage: config.stage,
     },
     custom: {
       logForwarding,


### PR DESCRIPTION
Fixes #73 

TODOS
- [x] document schema
- [x] manually verify JSON schema (https://www.jsonschemavalidator.net/)[https://www.jsonschemavalidator.net/]
- [x] Verify that unit tests still run
  - I didn't see an easy way to add unit tests for the json schema 🤔
- [ ] Test that when using this version of the plugin the console warning is no longer rendered
  - If the maintainer of this repo easily can do the test that would be really great, need to figure out how to link a local version of a plugin into my codebase